### PR TITLE
fix(test): invalid JSON settings.

### DIFF
--- a/e2e.bats
+++ b/e2e.bats
@@ -21,7 +21,7 @@
 }
 
 @test "Fallback cannot be in the denied storage classes list" {
-	run kwctl run  --request-path test_data/pvc-fast-storage-class-request.json --settings-json '{"deniedStorageClasses":["fast"], fallbackStorageClass: "fast"}'  annotated-policy.wasm
+	run kwctl run  --request-path test_data/pvc-fast-storage-class-request.json --settings-json '{"deniedStorageClasses":["fast"], "fallbackStorageClass": "fast"}'  annotated-policy.wasm
 
 	  # this prints the output when one the checks below fails
 	  echo "output = ${output}"


### PR DESCRIPTION
## Description

The e2e tests are failing due a invalid JSON string used in one of the tests. The JSON field was missing the `"` around its name.

Fix issue in CI found at https://github.com/kubewarden/persistentvolumeclaim-storageclass-policy/pull/85
