### PR TITLE
feat: allow list settings.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.9.3"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "cfg-if"
@@ -601,9 +601,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
 dependencies = [
  "zerovec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-k8s-openapi = { version = "0.25.0", default_features = false, features = [
+k8s-openapi = { version = "0.25", default-features = false, features = [
   "v1_32",
 ] }
-kubewarden-policy-sdk = "0.14.0"
+kubewarden-policy-sdk = "0.14"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rstest = "0.26"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,36 +117,92 @@ fn mutate_request(
     }
 }
 
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-//     use k8s_openapi::apimachinery::pkg::apis::meta::v1 as metav1;
-//     use kubewarden::response::ValidationResponse;
-//
-//     // #[test]
-//     // fn validate_request_mutation() {
-//     //     let fallback_storage_class = "fallback-storage-class".to_string();
-//     //     let pvc = apicore::PersistentVolumeClaim {
-//     //         metadata: metav1::ObjectMeta {
-//     //             name: Some("pvc".to_string()),
-//     //             ..Default::default()
-//     //         },
-//     //         spec: Some(apicore::PersistentVolumeClaimSpec {
-//     //             storage_class_name: Some("invalid-storage-class".to_string()),
-//     //             ..Default::default()
-//     //         }),
-//     //         ..Default::default()
-//     //     };
-//     //     let response = mutate_request(pvc, &Some(fallback_storage_class.clone()));
-//     //     let response_object: ValidationResponse =
-//     //         serde_json::from_slice(&response.unwrap()).unwrap();
-//     //     let mutated_pvc = serde_json::from_value::<apicore::PersistentVolumeClaim>(
-//     //         response_object.mutated_object.unwrap(),
-//     //     )
-//     //     .unwrap();
-//     //     assert_eq!(
-//     //         mutated_pvc.spec.unwrap().storage_class_name.unwrap(),
-//     //         fallback_storage_class
-//     //     );
-//     // }
-// }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1 as metav1;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::pvc_class_in_denined_list_should_reject(vec![], vec!["slow", "standard"], None, "slow", false)]
+    #[case::pvc_class_not_in_denied_list_should_accept(vec![], vec!["slow", "standard"], None, "fast", true)]
+    #[case::pvc_class_should_fallback_when_using_class_from_denined_list(vec![], vec!["slow", "standard"], Some("fast"), "slow", true)]
+    #[case::pvc_class_not_in_allowed_list_should_reject(vec!["slow", "standard"], vec![], None, "fast", false)]
+    #[case::pvc_class_in_allowed_list_should_accept(vec!["slow", "standard"], vec![], None, "slow", true)]
+    #[case::pvc_class_not_in_allowed_list_should_fallback(vec!["slow", "standard"], vec![], Some("slow"), "fast", true)]
+    fn validation_tests(
+        #[case] allowed_storage_classes_list: Vec<&str>,
+        #[case] denied_storage_classes_list: Vec<&str>,
+        #[case] fallback_storage_class: Option<&str>,
+        #[case] storage_class_name: &str,
+        #[case] should_accept: bool,
+    ) {
+        use kubewarden::response::ValidationResponse;
+
+        let denied_storage_classes: HashSet<String> = denied_storage_classes_list
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect();
+        let allowed_storage_classes: HashSet<String> = allowed_storage_classes_list
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect();
+        let pvc = apicore::PersistentVolumeClaim {
+            metadata: metav1::ObjectMeta {
+                name: Some("pvc".to_string()),
+                ..Default::default()
+            },
+            spec: Some(apicore::PersistentVolumeClaimSpec {
+                storage_class_name: Some(storage_class_name.to_owned()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let result = if !allowed_storage_classes.is_empty() {
+            validate_allowed_classes(
+                pvc,
+                storage_class_name.to_owned(),
+                allowed_storage_classes,
+                fallback_storage_class.map(|s| s.to_owned()),
+            )
+        } else {
+            validate_denied_classes(
+                pvc,
+                storage_class_name.to_owned(),
+                denied_storage_classes,
+                fallback_storage_class.map(|s| s.to_owned()),
+            )
+        }
+        .expect("CallResult should be Ok");
+
+        let response: ValidationResponse =
+            serde_json::from_slice(result.as_slice()).expect("Response should be valid JSON");
+        assert!(should_accept == response.accepted);
+        if should_accept {
+            assert_eq!(
+                fallback_storage_class.is_none(),
+                response.mutated_object.is_none(),
+            );
+            if fallback_storage_class.is_some() {
+                let mutated_pvc = serde_json::from_value::<apicore::PersistentVolumeClaim>(
+                    response.mutated_object.expect("Missing mutated object"),
+                )
+                .expect("Mutated object should be a valid PVC");
+                assert_eq!(
+                    mutated_pvc
+                        .spec
+                        .expect("Missing spec")
+                        .storage_class_name
+                        .expect("Missing storage class name"),
+                    fallback_storage_class.expect("Missing fallback storage class")
+                );
+            }
+        } else {
+            assert_eq!(
+                response.message.expect("Missing error message"),
+                format!("storage class \"{}\" is not allowed", storage_class_name)
+            );
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,12 @@
+use std::collections::HashSet;
+
 use guest::prelude::*;
 use kubewarden_policy_sdk::wapc_guest as guest;
 
-use k8s_openapi::api::core::v1 as apicore;
+use k8s_openapi::api::core::v1::{self as apicore, PersistentVolumeClaim};
 
 extern crate kubewarden_policy_sdk as kubewarden;
 use kubewarden::{protocol_version_guest, request::ValidationRequest, validate_settings};
-
 mod settings;
 use settings::Settings;
 
@@ -28,126 +29,124 @@ fn validate(payload: &[u8]) -> CallResult {
             return kubewarden::accept_request();
         }
     };
-    let (use_denied_class, storage_class_name) =
-        uses_denied_storage_class(&pvc, &validation_request.settings);
-    if use_denied_class {
-        if validation_request.settings.fallback_storage_class.is_some() {
-            return mutate_request(pvc, &validation_request.settings);
-        }
-        return kubewarden::reject_request(
-            Some(format!(
-                "storage class \"{}\" is not allowed",
-                storage_class_name.unwrap_or_default()
-            )),
-            None,
-            None,
-            None,
-        );
-    }
-    kubewarden::accept_request()
-}
 
-fn mutate_request(pvc: apicore::PersistentVolumeClaim, settings: &Settings) -> CallResult {
-    let mutated_pvc = serde_json::to_value(apicore::PersistentVolumeClaim {
-        spec: Some(apicore::PersistentVolumeClaimSpec {
-            storage_class_name: settings.fallback_storage_class.clone(),
-            ..pvc.spec.unwrap_or_default()
-        }),
-        ..pvc
-    })?;
-    kubewarden::mutate_request(mutated_pvc)
-}
-
-fn uses_denied_storage_class(
-    pvc: &apicore::PersistentVolumeClaim,
-    settings: &Settings,
-) -> (bool, Option<String>) {
     let storage_class_name = pvc
         .spec
         .as_ref()
         .and_then(|spec| spec.storage_class_name.clone())
         .unwrap_or_default();
 
-    if settings
-        .denied_storage_classes
-        .contains(&storage_class_name)
+    if validation_request
+        .settings
+        .allowed_storage_classes
+        .is_some()
     {
-        return (true, Some(storage_class_name));
-    }
-    (false, None)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use k8s_openapi::apimachinery::pkg::apis::meta::v1 as metav1;
-    use kubewarden::response::ValidationResponse;
-    use rstest::rstest;
-    use std::collections::HashSet;
-
-    #[rstest]
-    #[case("valid-storage-class", vec![], None)]
-    #[case("valid-storage-class", vec!["invalid-storage-class-name".to_owned()], None)]
-    #[case("invalid-storage-class", vec!["invalid-storage-class-name".to_owned()], None)]
-    fn validate_storage_class_name(
-        #[case] storage_class_name: &str,
-        #[case] denied_storage_classes_list: Vec<String>,
-        #[case] fallback_storage_class: Option<String>,
-    ) {
-        let settings = Settings {
-            denied_storage_classes: HashSet::from_iter(denied_storage_classes_list.iter().cloned()),
-            fallback_storage_class,
-        };
-        let pvc = apicore::PersistentVolumeClaim {
-            metadata: metav1::ObjectMeta {
-                name: Some("valid-pvc".to_string()),
-                ..Default::default()
-            },
-            spec: Some(apicore::PersistentVolumeClaimSpec {
-                storage_class_name: Some(storage_class_name.to_string()),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-        let (use_denied_class, returned_storage_class_name) =
-            uses_denied_storage_class(&pvc, &settings);
-
-        if denied_storage_classes_list.contains(&storage_class_name.to_owned()) {
-            assert!(use_denied_class);
-            assert_eq!(returned_storage_class_name.unwrap(), storage_class_name);
-        } else {
-            assert!(!use_denied_class);
-            assert_eq!(returned_storage_class_name, None);
-        }
-    }
-
-    #[test]
-    fn validate_request_mutation() {
-        let settings = Settings {
-            denied_storage_classes: HashSet::new(), //this field is not used in this test
-            fallback_storage_class: Some("fallback-storage-class".to_string()),
-        };
-        let pvc = apicore::PersistentVolumeClaim {
-            metadata: metav1::ObjectMeta {
-                name: Some("pvc".to_string()),
-                ..Default::default()
-            },
-            spec: Some(apicore::PersistentVolumeClaimSpec {
-                storage_class_name: Some("invalid-storage-class".to_string()),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-        let response = mutate_request(pvc, &settings);
-        let response_object: ValidationResponse =
-            serde_json::from_slice(&response.unwrap()).unwrap();
-        let mutated_pvc = serde_json::from_value::<apicore::PersistentVolumeClaim>(
-            response_object.mutated_object.unwrap(),
-        )
-        .unwrap();
-        assert_eq!(
-            mutated_pvc.spec.unwrap().storage_class_name.unwrap(),
-            settings.fallback_storage_class.unwrap()
+        return validate_allowed_classes(
+            pvc,
+            storage_class_name,
+            validation_request.settings.allowed_storage_classes.unwrap(),
+            validation_request.settings.fallback_storage_class,
         );
     }
+    validate_denied_classes(
+        pvc,
+        storage_class_name,
+        validation_request.settings.denied_storage_classes.unwrap(),
+        validation_request.settings.fallback_storage_class,
+    )
 }
+
+// This function is the common logic to either allow or deny list a storage class.
+// If a fallback storage class is set, the request will be mutated to use it.
+// If not, the request will be rejected.
+fn mutate_or_reject(
+    pvc: PersistentVolumeClaim,
+    storage_class_name: String,
+    fallback_storage_class: Option<String>,
+) -> CallResult {
+    if fallback_storage_class.is_some() {
+        let mutated_pvc = mutate_request(pvc, fallback_storage_class);
+        let json_value = serde_json::to_value(&mutated_pvc)?;
+        return kubewarden::mutate_request(json_value);
+    }
+    kubewarden::reject_request(
+        Some(format!(
+            "storage class \"{}\" is not allowed",
+            storage_class_name,
+        )),
+        None,
+        None,
+        None,
+    )
+}
+
+fn validate_allowed_classes(
+    pvc: PersistentVolumeClaim,
+    storage_class_name: String,
+    allowed_storage_classes: HashSet<String>,
+    fallback_storage_class: Option<String>,
+) -> CallResult {
+    if allowed_storage_classes.contains(&storage_class_name) {
+        return kubewarden::accept_request();
+    }
+    mutate_or_reject(pvc, storage_class_name, fallback_storage_class)
+}
+
+fn validate_denied_classes(
+    pvc: PersistentVolumeClaim,
+    storage_class_name: String,
+    denied_storage_classes: HashSet<String>,
+    fallback_storage_class: Option<String>,
+) -> CallResult {
+    if denied_storage_classes.contains(&storage_class_name) {
+        return mutate_or_reject(pvc, storage_class_name, fallback_storage_class);
+    }
+    kubewarden::accept_request()
+}
+
+fn mutate_request(
+    pvc: apicore::PersistentVolumeClaim,
+    fallback_storage_class: Option<String>,
+) -> apicore::PersistentVolumeClaim {
+    apicore::PersistentVolumeClaim {
+        spec: Some(apicore::PersistentVolumeClaimSpec {
+            storage_class_name: fallback_storage_class.clone(),
+            ..pvc.spec.unwrap_or_default()
+        }),
+        ..pvc
+    }
+}
+
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     use k8s_openapi::apimachinery::pkg::apis::meta::v1 as metav1;
+//     use kubewarden::response::ValidationResponse;
+//
+//     // #[test]
+//     // fn validate_request_mutation() {
+//     //     let fallback_storage_class = "fallback-storage-class".to_string();
+//     //     let pvc = apicore::PersistentVolumeClaim {
+//     //         metadata: metav1::ObjectMeta {
+//     //             name: Some("pvc".to_string()),
+//     //             ..Default::default()
+//     //         },
+//     //         spec: Some(apicore::PersistentVolumeClaimSpec {
+//     //             storage_class_name: Some("invalid-storage-class".to_string()),
+//     //             ..Default::default()
+//     //         }),
+//     //         ..Default::default()
+//     //     };
+//     //     let response = mutate_request(pvc, &Some(fallback_storage_class.clone()));
+//     //     let response_object: ValidationResponse =
+//     //         serde_json::from_slice(&response.unwrap()).unwrap();
+//     //     let mutated_pvc = serde_json::from_value::<apicore::PersistentVolumeClaim>(
+//     //         response_object.mutated_object.unwrap(),
+//     //     )
+//     //     .unwrap();
+//     //     assert_eq!(
+//     //         mutated_pvc.spec.unwrap().storage_class_name.unwrap(),
+//     //         fallback_storage_class
+//     //     );
+//     // }
+// }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -3,24 +3,56 @@ use std::collections::HashSet;
 
 // Describe the settings your policy expects when
 // loaded by the policy server.
-#[derive(Serialize, Deserialize, Default, Debug)]
-#[serde(default)]
+#[derive(Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct Settings {
-    pub(crate) denied_storage_classes: HashSet<String>,
-    pub(crate) fallback_storage_class: Option<String>,
+    pub denied_storage_classes: Option<HashSet<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fallback_storage_class: Option<String>,
+    pub allowed_storage_classes: Option<HashSet<String>>,
 }
 
 impl kubewarden::settings::Validatable for Settings {
     fn validate(&self) -> Result<(), String> {
-        if self.denied_storage_classes.is_empty() {
+        if self.denied_storage_classes.is_none() && self.allowed_storage_classes.is_none() {
+            return Err(
+                "One of deniedStorageClasses or allowedStorageClasses must be set".to_string(),
+            );
+        }
+        if self.denied_storage_classes.is_some() && self.allowed_storage_classes.is_some() {
+            return Err(
+                "Only one of deniedStorageClasses or allowedStorageClasses can be set".to_string(),
+            );
+        }
+        if self.denied_storage_classes.is_some()
+            && self.denied_storage_classes.as_ref().unwrap().is_empty()
+        {
             return Err("deniedStorageClasses cannot be empty".to_string());
         }
-        if self
-            .denied_storage_classes
-            .contains(&self.fallback_storage_class.clone().unwrap_or_default())
+        if self.denied_storage_classes.is_some()
+            && self.fallback_storage_class.is_some()
+            && self
+                .denied_storage_classes
+                .as_ref()
+                .unwrap()
+                .contains(self.fallback_storage_class.as_ref().unwrap())
         {
             return Err("fallbackStorageClass cannot be in deniedStorageClasses".to_string());
+        }
+        if self.allowed_storage_classes.is_some()
+            && self.allowed_storage_classes.as_ref().unwrap().is_empty()
+        {
+            return Err("allowedStorageClasses cannot be empty".to_string());
+        }
+        if self.allowed_storage_classes.is_some()
+            && self.fallback_storage_class.is_some()
+            && !self
+                .allowed_storage_classes
+                .as_ref()
+                .unwrap()
+                .contains(self.fallback_storage_class.as_ref().unwrap())
+        {
+            return Err("fallbackStorageClass must be in allowedStorageClasses".to_string());
         }
         Ok(())
     }
@@ -35,8 +67,9 @@ mod tests {
     #[test]
     fn validate_settings_with_fallback_inside_denied_storage_class_list() {
         let settings = Settings {
-            denied_storage_classes: HashSet::from(["foo".to_string(), "bar".to_string()]),
+            denied_storage_classes: Some(HashSet::from(["foo".to_string(), "bar".to_string()])),
             fallback_storage_class: Some("bar".to_string()),
+            ..Default::default()
         };
         assert!(settings.validate().is_err());
         assert_eq!(
@@ -51,15 +84,16 @@ mod tests {
         assert!(settings.validate().is_err());
         assert_eq!(
             settings.validate().unwrap_err(),
-            "deniedStorageClasses cannot be empty".to_string()
+            "One of deniedStorageClasses or allowedStorageClasses must be set".to_string()
         );
     }
 
     #[test]
     fn validate_settings_with_empty_storage_classes_list() {
         let settings = Settings {
-            denied_storage_classes: HashSet::new(),
+            denied_storage_classes: Some(HashSet::new()),
             fallback_storage_class: None,
+            ..Default::default()
         };
         assert!(settings.validate().is_err());
         assert_eq!(
@@ -71,8 +105,9 @@ mod tests {
     #[test]
     fn validate_settings() {
         let settings = Settings {
-            denied_storage_classes: HashSet::from(["foo".to_string(), "bar".to_string()]),
+            denied_storage_classes: Some(HashSet::from(["foo".to_string(), "bar".to_string()])),
             fallback_storage_class: None,
+            ..Default::default()
         };
         assert!(settings.validate().is_ok());
     }
@@ -80,8 +115,53 @@ mod tests {
     #[test]
     fn validate_settings_with_fallback() {
         let settings = Settings {
-            denied_storage_classes: HashSet::from(["foo".to_string(), "bar".to_string()]),
+            denied_storage_classes: Some(HashSet::from(["foo".to_string(), "bar".to_string()])),
             fallback_storage_class: Some("baz".to_string()),
+            ..Default::default()
+        };
+        assert!(settings.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_settings_with_empty_allowed_storage_classes_list() {
+        let settings = Settings {
+            allowed_storage_classes: Some(HashSet::new()),
+            ..Default::default()
+        };
+        assert_eq!(
+            settings.validate().expect_err("Expected error"),
+            "allowedStorageClasses cannot be empty".to_string()
+        );
+    }
+
+    #[test]
+    fn validate_non_empty_allowed_storage_classes_list_settings() {
+        let settings = Settings {
+            allowed_storage_classes: Some(HashSet::from(["foo".to_string(), "bar".to_string()])),
+            ..Default::default()
+        };
+        assert!(settings.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_fallback_should_be_defined_in_allowed_list() {
+        let settings = Settings {
+            allowed_storage_classes: Some(HashSet::from(["foo".to_string(), "bar".to_string()])),
+            fallback_storage_class: Some("baz".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            settings.validate().expect_err("Expected error"),
+            "fallbackStorageClass must be in allowedStorageClasses".to_string()
+        );
+    }
+
+    #[test]
+    fn validate_fallback_should_be_defined_in_allowed_list2() {
+        let settings = Settings {
+            allowed_storage_classes: Some(HashSet::from(["foo".to_string(), "bar".to_string()])),
+            fallback_storage_class: Some("foo".to_string()),
+            ..Default::default()
         };
         assert!(settings.validate().is_ok());
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,13 +1,22 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
+// Error message constants
+const ERR_ONE_OF_DENIED_OR_ALLOWED_MUST_BE_SET: &str =
+    "One of deniedStorageClasses or allowedStorageClasses must be set";
+const ERR_ONLY_ONE_OF_DENIED_OR_ALLOWED_CAN_BE_SET: &str =
+    "Only one of deniedStorageClasses or allowedStorageClasses can be set";
+const ERR_DENIED_CANNOT_BE_EMPTY: &str = "deniedStorageClasses cannot be empty";
+const ERR_FALLBACK_IN_DENIED: &str = "fallbackStorageClass cannot be in deniedStorageClasses";
+const ERR_ALLOWED_CANNOT_BE_EMPTY: &str = "allowedStorageClasses cannot be empty";
+const ERR_FALLBACK_NOT_IN_ALLOWED: &str = "fallbackStorageClass must be in allowedStorageClasses";
+
 // Describe the settings your policy expects when
 // loaded by the policy server.
 #[derive(Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct Settings {
     pub denied_storage_classes: Option<HashSet<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub fallback_storage_class: Option<String>,
     pub allowed_storage_classes: Option<HashSet<String>>,
 }
@@ -15,45 +24,37 @@ pub(crate) struct Settings {
 impl kubewarden::settings::Validatable for Settings {
     fn validate(&self) -> Result<(), String> {
         if self.denied_storage_classes.is_none() && self.allowed_storage_classes.is_none() {
-            return Err(
-                "One of deniedStorageClasses or allowedStorageClasses must be set".to_string(),
-            );
+            return Err(ERR_ONE_OF_DENIED_OR_ALLOWED_MUST_BE_SET.to_string());
         }
+
         if self.denied_storage_classes.is_some() && self.allowed_storage_classes.is_some() {
-            return Err(
-                "Only one of deniedStorageClasses or allowedStorageClasses can be set".to_string(),
-            );
+            return Err(ERR_ONLY_ONE_OF_DENIED_OR_ALLOWED_CAN_BE_SET.to_string());
         }
-        if self.denied_storage_classes.is_some()
-            && self.denied_storage_classes.as_ref().unwrap().is_empty()
-        {
-            return Err("deniedStorageClasses cannot be empty".to_string());
+
+        if let Some(denied_storage_classes) = &self.denied_storage_classes {
+            if denied_storage_classes.is_empty() {
+                return Err(ERR_DENIED_CANNOT_BE_EMPTY.to_string());
+            }
+
+            if let Some(fallback_storage_class) = &self.fallback_storage_class {
+                if denied_storage_classes.contains(fallback_storage_class) {
+                    return Err(ERR_FALLBACK_IN_DENIED.to_string());
+                }
+            }
         }
-        if self.denied_storage_classes.is_some()
-            && self.fallback_storage_class.is_some()
-            && self
-                .denied_storage_classes
-                .as_ref()
-                .unwrap()
-                .contains(self.fallback_storage_class.as_ref().unwrap())
-        {
-            return Err("fallbackStorageClass cannot be in deniedStorageClasses".to_string());
+
+        if let Some(allowed_storage_classes) = &self.allowed_storage_classes {
+            if allowed_storage_classes.is_empty() {
+                return Err(ERR_ALLOWED_CANNOT_BE_EMPTY.to_string());
+            }
+
+            if let Some(fallback_storage_class) = &self.fallback_storage_class {
+                if !allowed_storage_classes.contains(fallback_storage_class) {
+                    return Err(ERR_FALLBACK_NOT_IN_ALLOWED.to_string());
+                }
+            }
         }
-        if self.allowed_storage_classes.is_some()
-            && self.allowed_storage_classes.as_ref().unwrap().is_empty()
-        {
-            return Err("allowedStorageClasses cannot be empty".to_string());
-        }
-        if self.allowed_storage_classes.is_some()
-            && self.fallback_storage_class.is_some()
-            && !self
-                .allowed_storage_classes
-                .as_ref()
-                .unwrap()
-                .contains(self.fallback_storage_class.as_ref().unwrap())
-        {
-            return Err("fallbackStorageClass must be in allowedStorageClasses".to_string());
-        }
+
         Ok(())
     }
 }
@@ -66,61 +67,61 @@ mod tests {
     use rstest::rstest;
 
     #[rstest]
-    #[case::fallback_cannot_be_in_denied_list(
+    #[case::empty_settings_is_not_valid(
+        None,
+        None,
+        None,
+        Some(ERR_ONE_OF_DENIED_OR_ALLOWED_MUST_BE_SET)
+    )]
+    #[case::using_deny_and_allow_lists_at_the_same_time_is_not_valid(
+        Some(HashSet::from(["foo", "bar"])),
+        Some(HashSet::from(["foo", "bar"])),
+        None,
+        Some(ERR_ONLY_ONE_OF_DENIED_OR_ALLOWED_CAN_BE_SET)
+    )]
+    #[case::empty_denied_list_is_not_valid(
+        None,
+        Some(HashSet::new()),
+        None,
+        Some(ERR_DENIED_CANNOT_BE_EMPTY)
+    )]
+    #[case::empty_allowed_list_is_not_valid(
+        Some(HashSet::new()),
+        None,
+        None,
+        Some(ERR_ALLOWED_CANNOT_BE_EMPTY)
+    )]
+    #[case::denied_list_with_some_item_is_valid(
+        None,
+        Some(HashSet::from(["foo", "bar"])), 
+        None,
+        None)]
+    #[case::allowed_list_with_some_item_is_valid(
+        Some(HashSet::from(["foo", "bar"])),
+        None,
+        None,
+        None,
+    )]
+    #[case::fallback_in_denied_list_is_not_valid(
         None,
         Some(HashSet::from(["foo", "bar"])), 
         Some("bar"), 
-        Some("fallbackStorageClass cannot be in deniedStorageClasses"))]
-    #[case::fallback_not_in_denied_list_is_allowed(
+        Some(ERR_FALLBACK_IN_DENIED))]
+    #[case::fallback_not_in_denied_list_is_valid(
         None,
         Some(HashSet::from(["foo", "bar"])), 
         Some("baz"), 
         None)]
-    #[case::denined_list_cannot_be_empty(
-        None,
-        Some(HashSet::new()),
-        None,
-        Some("deniedStorageClasses cannot be empty")
-    )]
-    #[case::denined_list_must_has_some_item(
-        None,
-        Some(HashSet::from(["foo", "bar"])), 
-        None,
-        None)]
-    #[case::alloed_list_cannot_be_empty(
-        Some(HashSet::new()),
-        None,
-        None,
-        Some("allowedStorageClasses cannot be empty")
-    )]
-    #[case::allowed_list_must_has_some_item(
-        Some(HashSet::from(["foo", "bar"])),
-        None,
-        None,
-        None,
-    )]
-    #[case::fallback_class_must_be_in_allowed_list(
+    #[case::fallback_class_not_in_allowed_list_is_not_valid(
         Some(HashSet::from(["foo", "bar"])),
         None,
         Some("baz"), 
-        Some("fallbackStorageClass must be in allowedStorageClasses"))]
-    #[case::fallback_class_in_allowed_list_must_be_ok(
+        Some(ERR_FALLBACK_NOT_IN_ALLOWED))]
+    #[case::fallback_class_in_allowed_list_is_valid(
         Some(HashSet::from(["foo", "bar"])),
         None,
         Some("foo"), 
         None)]
-    #[case::empty_settings_are_not_allowed(
-        None,
-        None,
-        None,
-        Some("One of deniedStorageClasses or allowedStorageClasses must be set")
-    )]
-    #[case::empty_settings_are_not_allowed(
-        Some(HashSet::from(["foo", "bar"])),
-        Some(HashSet::from(["foo", "bar"])),
-        None,
-        Some("Only one of deniedStorageClasses or allowedStorageClasses can be set")
-    )]
     fn settings_validation(
         #[case] allowed_storage_classes: Option<HashSet<&str>>,
         #[case] denied_storage_classes: Option<HashSet<&str>>,
@@ -129,14 +130,14 @@ mod tests {
     ) {
         let settings = Settings {
             denied_storage_classes: denied_storage_classes
-                .to_owned()
                 .map(|set| set.into_iter().map(String::from).collect()),
             allowed_storage_classes: allowed_storage_classes
-                .to_owned()
                 .map(|set| set.into_iter().map(String::from).collect()),
             fallback_storage_class: fallback_storage_class.map(String::from),
         };
+
         let validation_result = settings.validate();
+
         if let Some(expected_error) = expected_error {
             assert_eq!(
                 validation_result.expect_err("Missing validation error"),


### PR DESCRIPTION
## Description

 Introduce the "allowedStorageClasses" settings option in the policy. This new settings is mutual exclusive with the "deniedStorageClasses". The new field allow the user to define the allowed storage classes that a PVC can have.

The unit tests have been refactored to use rstest. 

Fix #104 

## Test

```shell
make annotated-policy.wasm test e2e-tests 
```
